### PR TITLE
Spelling mistakes bug fix

### DIFF
--- a/solutions/monitoring_istio/index.asciidoc
+++ b/solutions/monitoring_istio/index.asciidoc
@@ -8,11 +8,11 @@
 
 == Why do I need Istio for my monitoring?
 
-These two articles should give you an idea why you need monitorin and why you would want to configure it with istio.
+These two articles should give you an idea why you need monitoring and why you would want to configure it with Istio.
 
 To get an understanding of what Istio is and why you should use it regardless of your intend to implement monitoring we recommend you to read their https://istio.io/latest/about/service-mesh/[introduction] about service mesh.
 
-For most of your monitoring questions you might want to read the https://istio.io/latest/docs/concepts/observability/["Observability"] section from the official istio https://istio.io/latest/docs/[documentation]. 
+For most of your monitoring questions you might want to read the https://istio.io/latest/docs/concepts/observability/["Observability"] section from the official Istio https://istio.io/latest/docs/[documentation]. 
 
 //Abstract
 == Core elements of the problem and its solution
@@ -20,8 +20,8 @@ For most of your monitoring questions you might want to read the https://istio.i
 //Communication:  
 //Now, we want to maintain the communication between the individual microservices uniformly by default.
 
-Our solution is tailored for when istio is running on the existing cluster and monitoring of the various microservices is attempted.
-We are in an environment of docker, kubernetes, microservices and istio. The idea here is that a cluster consists of microservices and runs with docker over kubernetes.  In addition, we would like to find a way how we can monitor our cluster with the individual microservices and accordingly make some analyses via prometheus or grafana. Now we present a solution following for how we have implemented this scenario. Our final project was a cluster with three different namespaces: Istio, Application and Monitoring. On the Istio namespace the normal istio system is running and the solution was tested with the default demo https://istio.io/latest/docs/setup/additional-setup/config-profiles/[profile]. The application namespace runs all microservices and the monitoring namespace is where we want to do the monitoring.
+Our solution is tailored for when Istio is running on the existing cluster and monitoring of the various microservices is attempted.
+We are in an environment of Docker, Kubernetes, microservices and Istio. The idea here is that a cluster consists of microservices and runs with Docker over Kubernetes.  In addition, we would like to find a way how we can monitor our cluster with the individual microservices and accordingly make some analyses via Prometheus or Grafana. Now we present a solution following for how we have implemented this scenario. Our final project was a cluster with three different namespaces: Istio, Application and Monitoring. On the Istio namespace the normal Istio system is running and the solution was tested with the default demo https://istio.io/latest/docs/setup/additional-setup/config-profiles/[profile]. The application namespace runs all microservices and the monitoring namespace is where we want to do the monitoring.
 
 We used the following tools to solve the problem:
 
@@ -34,17 +34,17 @@ We used the following tools to solve the problem:
 
 //Instruction and goals
 == Introduction
-Assumed is a kubernetes cluster with istio installed and running microservices. We will continuously show how you can monitor your cluster with the microservices using prometheus/grafana and how you can split the tasks into different namespaces. 
+Assumed is a Kubernetes cluster with Istio installed and running microservices. We will continuously show how you can monitor your cluster with the microservices using Prometheus and Grafana and how you can split the tasks into different namespaces. 
 
 == Prerequisites 
-* basic docker runs on your environment https://docs.docker.com/get-docker/[(docker install)]
-* kubernetes running with istio https://istio.io/latest/docs/setup/getting-started/[(istio install)]
+* basic Docker runs on your environment https://docs.docker.com/get-docker/[(docker install)]
+* Kubernetes running with Istio https://istio.io/latest/docs/setup/getting-started/[(istio install)]
 * you will need a gateway that exposes your application to incoming traffic 
 
 === For the future (optional)
-If your existing application doesn't satisfy this Prerequisites you can setup an istio ingress-gateway by following this https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/[link] and adapt the configuration to your needs
+If your existing application doesn't satisfy this prerequisites you can setup an istio ingress-gateway by following this https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/[link] and adapt the configuration to your needs.
 
-We offer a basic xref:Files/ingressgateway.yaml[ingressgateway.yaml] for this step but the configuration varies drastically depending on your specific application. Configuring an istio-ingressgateway or any other gateway is most likely mandatory but out of scope for this solution. Therefor we only covered the bare minimum. 
+We offer a basic xref:Files/ingressgateway.yaml[ingressgateway.yaml] for this step but the configuration varies drastically depending on your specific application. Configuring an istio-ingressgateway or any other gateway is most likely mandatory but out of scope for this solution. Therefore we have only covered the bare minimum. 
 
 == Requirements
 * adapt the walkthrough of deploying the https://istio.io/latest/docs/setup/getting-started/#bookinfo[sample application] to deploy your own application in the application namespace: <<creating_namespaces>>
@@ -59,9 +59,9 @@ Our goal is to have a cluster with 3 namespaces and the monitoring shall be in i
 
 In detail we want the following:
 
-* a standard istio namespace
+* a standard Istio namespace
 * run standard microservices in the application namespace
-* intercept the metrics created by istio and process them by our monitoring namespace
+* intercept the metrics created by Istio and process them by our monitoring namespace
 
 image::monitoring-architecture-simple.png[Namespaces Architecture Simple, width=100%, height=100%]
 
@@ -77,7 +77,7 @@ We would like to walk you through our decision making, why we think that you sho
 
 //Solution Strategy
 == Solution Strategy
-The setup of the namespace *istio-system* is indirectly already done, because istio is already installed on our system and therefore the namespace is created automatically. The next namespace where we don't have to care much is the *application* namespace, there we only have to add all our microservices which run in our cluster.
+The setup of the namespace *istio-system* is indirectly already done, because Istio is already installed on our system and therefore the namespace is created automatically. The next namespace where we don't have to care much is the *Application* namespace, there we only have to add all our microservices which run in our cluster.
 
 image::monitoring-namespaces.png[Namespaces Architecture, width=100%, height=100%]
  
@@ -113,7 +113,7 @@ We are defining targets for each of our jobs, which are scraped through the Kube
 image::monitoring-architecture-prometheus-endpoints.png[Namespaces Architecture - Prometheus endpoints, width=100%, height=100%]
 == Deploy Prometheus and Grafana in your monitoring namespace
 
-The namespace with the *monitoring* will be a bit more complex, because we have to adjust the config files of Prometheus and Grafana. We have oriented ourselves as it can be seen in this https://istiobyexample.dev/prometheus/[example] +
+The namespace with the *Monitoring* will be a bit more complex, because we have to adjust the config files of Prometheus and Grafana. We have oriented ourselves as it can be seen in this https://istiobyexample.dev/prometheus/[example] +
  *(1) Grafana Monitoring Namespace* - Part 1
 ```YAML
   ---
@@ -369,10 +369,10 @@ Add microservice retroactively to our application namespace:
  kubectl apply -f MICROSERVICE.yaml -n application `
 ```
 
-Now you can install istio on your cluster. You only have to install istio in general as described above. Afterwards you can activate istio on single namespaces as soon as istio is installed on the cluster. To enable istio on our application namespace we have to do the following(if namespace created as described above, no action needed): [ADD CODE FRAGMENT].
+Now you can install Istio on your cluster. You only have to install Istio in general as described above. Afterwards you can activate Istio on single namespaces as soon as Istio is installed on the cluster. To enable Istio on our application namespace we have to do the following(if namespace created as described above, no action needed): [ADD CODE FRAGMENT].
 //istio-sidecar?
 
-Now our cluster should already have our microservices running under the application namespace, istio should be installed and enabled on our namespace and now only the monitoring is missing. For this we focus on Grafana and Prometheus. With the istio installation Grafana and Prometheus are directly provided (istio\samples\addons). Now it is important not to use the standard config files of the monitoring tools, because they will be installed on the istio namespace and run over it. However we want to run them on our own monitoring namespace. Therefore we have to change the config files (grafana.yaml/prometheus.yaml). To do this you can follow our sample code from above. This shows an example of how to edit the config files to run on the separate monitoring namespace. Once you have customized your config files, you can enable them on your cluster with the simple kubernetes command: [ADD CODE FRAGMENT]. 
+Now our cluster should already have our microservices running under the application namespace, Istio should be installed and enabled on our namespace and now only the monitoring is missing. For this we focus on Grafana and Prometheus. With the Istio installation Grafana and Prometheus are directly provided (istio\samples\addons). Now it is important not to use the standard config files of the monitoring tools, because they will be installed on the istio namespace and run over it. However we want to run them on our own monitoring namespace. Therefore we have to change the config files (grafana.yaml/prometheus.yaml). To do this you can follow our sample code from above. This shows an example of how to edit the config files to run on the separate monitoring namespace. Once you have customized your config files, you can enable them on your cluster with the simple kubernetes command: [ADD CODE FRAGMENT]. 
 
 //Option 1
 // kubectl apply -f GRAFANA/PROMETHEUS.yaml


### PR DESCRIPTION
We might also reconsider the Rancher part since we have removed it from the prerequisites. 

In addition we should be consistent how we want to name the namespaces (Istio or the default name istio-system)